### PR TITLE
Screen area setting.

### DIFF
--- a/easytab.h
+++ b/easytab.h
@@ -588,6 +588,12 @@ typedef struct
     WTMGRCLOSE        WTMgrClose;
     WTMGRDEFCONTEXT   WTMgrDefContext;
     WTMGRDEFCONTEXTEX WTMgrDefContextEx;
+
+    // The output region can be configured by the user.
+    LONG    ScreenOriginX;
+    LONG    ScreenOriginY;
+    float   ScreenAreaRatioX;
+    float   ScreenAreaRatioY;
 #endif // WIN32
 } EasyTabInfo;
 
@@ -817,15 +823,29 @@ EasyTabResult EasyTab_Load_Ex(HWND Window,
         LogContext.lcMoveMask = PACKETDATA;
         LogContext.lcBtnUpMask = LogContext.lcBtnDnMask;
 
+        DWORD CoordRangeX = GetSystemMetrics(SM_CXSCREEN);
+        DWORD CoordRangeY = GetSystemMetrics(SM_CYSCREEN);
+
         LogContext.lcOutOrgX = 0;
         LogContext.lcOutOrgY = 0;
-        LogContext.lcOutExtX = GetSystemMetrics(SM_CXSCREEN);
-        LogContext.lcOutExtY = -GetSystemMetrics(SM_CYSCREEN);
+        LogContext.lcOutExtX = CoordRangeX;
+        LogContext.lcOutExtY = -CoordRangeY;
 
-        LogContext.lcSysOrgX = 0;
-        LogContext.lcSysOrgY = 0;
-        LogContext.lcSysExtX = GetSystemMetrics(SM_CXSCREEN);
-        LogContext.lcSysExtY = GetSystemMetrics(SM_CYSCREEN);
+        EasyTab->ScreenOriginX = LogContext.lcSysOrgX;
+        EasyTab->ScreenOriginY = LogContext.lcSysOrgY;
+        float SysExtX          = LogContext.lcSysExtX;
+        float SysExtY          = LogContext.lcSysExtY;
+
+        if (SysExtX != 0 && SysExtY != 0)
+        {
+            EasyTab->ScreenAreaRatioX = (float)CoordRangeX/SysExtX;
+            EasyTab->ScreenAreaRatioY = (float)CoordRangeY/SysExtY;
+        }
+        else
+        {
+            EasyTab->ScreenAreaRatioX = 1;
+            EasyTab->ScreenAreaRatioY = 1;
+        }
 
         if (TrackingMode == EASYTAB_TRACKING_MODE_RELATIVE)
         {
@@ -872,8 +892,8 @@ EasyTabResult EasyTab_HandleEvent(HWND Window, UINT Message, LPARAM LParam, WPAR
         EasyTab->WTPacket(EasyTab->Context, (UINT)WParam, &Packet))
     {
         POINT Point = { 0 };
-        Point.x = Packet.pkX;
-        Point.y = Packet.pkY;
+        Point.x = EasyTab->ScreenOriginX + Packet.pkX / EasyTab->ScreenAreaRatioX;
+        Point.y = EasyTab->ScreenOriginY + Packet.pkY / EasyTab->ScreenAreaRatioY;
         ScreenToClient(Window, &Point);
         EasyTab->PosX = Point.x;
         EasyTab->PosY = Point.y;


### PR DESCRIPTION
[Edit: Clarity. Also, I had said something about EasyTab not working with multiple monitors, which wasn't true! EasyTab was working, but setting the whole monitor as the output area. ]

This implements support for screen area mapping, which means not setting the SysOrg and SysExt variables in LogContext.

![screenshot 2016-06-06 20 55 16](https://cloud.githubusercontent.com/assets/282970/15845407/7640b8f8-2c38-11e6-9848-a66454763af0.png)

Looking at lines 895 and 896 of the PR:

```
       Point.x = EasyTab->ScreenOriginX + Packet.pkX / EasyTab->ScreenAreaRatioX;
       Point.y = EasyTab->ScreenOriginY + Packet.pkY / EasyTab->ScreenAreaRatioY;
```

when before it was:

```
        Point.x = Packet.pkX;
        Point.y = Packet.pkY;
```

This should work as before when the feature is not being used. 
- On a single monitor config, ScreenOrigin(X|Y) should be 0.
- When the feature is disabled, SysExt(X|Y) will be equal to CoordRange(X|Y), so ScreenAreaRatio(X|Y) will be 1. 

I tested it on my machine enabling only one monitor and toggling the feature, but please test it if you choose to merge this :)

The feature works as expected with Milton compared with other programs that support it (Krita, Mischief, Gimp) but I have only tried it out with Milton. Maybe test it with Papaya first?

Finally, requesting code review :)
