### PR TITLE
Fixed small memory leak by closing the device in EasyTab_Unload

### DIFF
--- a/easytab.h
+++ b/easytab.h
@@ -626,7 +626,7 @@ extern EasyTabInfo* EasyTab;
 
     EasyTabResult EasyTab_Load(Display* Disp, Window Win);
     EasyTabResult EasyTab_HandleEvent(XEvent* Event);
-    void EasyTab_Unload();
+    void EasyTab_Unload(Display* Disp);
 
 #elif defined(_WIN32)
 
@@ -751,8 +751,9 @@ EasyTabResult EasyTab_HandleEvent(XEvent* Event)
     return EASYTAB_OK;
 }
 
-void EasyTab_Unload()
+void EasyTab_Unload(Display* Disp)
 {
+    XCloseDevice(Disp, EasyTab->Device);
     free(EasyTab);
     EasyTab = NULL;
 }


### PR DESCRIPTION
Implemented a small fix to correct a memory leak when unloading EasyTab, the device handle returned by `XOpenDevice` was not being closed.

This does change the API, as unloading now requires a pointer to the `Display*` in order to close the device. I opted for this approach because it is more explicit and avoids retaining additional state. Alternatively, a copy to the original `Display*` passed in during load could be retained in the `EasyTabInfo` struct.
