### PR TITLE
Potential fix for Milton/HMH tablet issue

### DIFF
--- a/easytab.h
+++ b/easytab.h
@@ -932,7 +932,13 @@ EasyTabResult EasyTab_HandleEvent(HWND Window, UINT Message, LPARAM LParam, WPAR
     }
     else if (Message == WM_ACTIVATE && EasyTab->Context)
     {
+        // Extract the low word of WParam, which specifies whether the window became active or not
+        // see https://msdn.microsoft.com/en-us/library/windows/desktop/ms646274.aspx
         BOOL Active = (WParam & 0xFFFF) != 0;
+
+        // Enable / Disable the context when focus changes (e.g. our window is minimized)
+        // and move our context to the top with WTOverlap when we gain focus.
+        // see http://www.wacomeng.com/windows/docs/NotesForTabletAwarePCDevelopers.html#_Toc274818945
         EasyTab->WTEnable(EasyTab->Context, Active);
         if (Active)
         {

--- a/easytab.h
+++ b/easytab.h
@@ -930,6 +930,15 @@ EasyTabResult EasyTab_HandleEvent(HWND Window, UINT Message, LPARAM LParam, WPAR
         EasyTab->Buttons = Packet.pkButtons;
         return EASYTAB_OK;
     }
+    else if (Message == WM_ACTIVATE && EasyTab->Context)
+    {
+        BOOL Active = (WParam & 0xFFFF) != 0;
+        EasyTab->WTEnable(EasyTab->Context, Active);
+        if (Active)
+        {
+            EasyTab->WTOverlap(EasyTab->Context, TRUE);
+        }
+    }
 
     return EASYTAB_EVENT_NOT_HANDLED;
 }


### PR DESCRIPTION
On handmade hero, @cmuratori is running into an issue where the tablet input in @serge-rgb's Milton stops working occasionally, and I think at one point he noticed it happen when his timer overlay thing gained focus.

I looked into the WinTab stuff and think calling WTEnable and WTOverlap when focus changes might fix it, but I don't have a tablet to test it.